### PR TITLE
Some cleanup, jwalk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .fseventsd
 .idea/
 .LSOverride
+.specstory
 .Spotlight-V100
 .TemporaryItems
 .Trashes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +263,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -334,24 +365,23 @@ dependencies = [
 
 [[package]]
 name = "fontgrep"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "criterion",
  "dirs",
  "env_logger",
  "itertools 0.14.0",
+ "jwalk",
  "log",
  "memmap2",
  "num_cpus",
- "rayon",
  "regex",
  "serde",
  "serde_json",
  "skrifa",
  "tempfile",
  "thiserror",
- "walkdir",
 ]
 
 [[package]]
@@ -478,6 +508,16 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fontgrep"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = [
     "Simon Cozens <simon@simon-cozens.org>",
-    "Adam Twardoch <adam@twardoch.com>",
+    "Adam Twardoch <adam+github@twardoch.com>",
 ]
 description = "A tool to search for fonts based on various criteria"
 license = "MIT"
@@ -26,8 +26,7 @@ path = "src/main.rs"
 skrifa = "0.28.1"
 clap = { version = "4.4.6", features = ["derive"] }
 regex = "1.9.5"
-rayon = "1.8.0"
-walkdir = "2.4.0"
+jwalk = "0.8.1"
 thiserror = "1.0.48"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"

--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ A command-line tool for searching and analyzing font files based on various crit
   - Font tables (e.g., GPOS, GSUB)
   - Unicode character support
   - Font name patterns
-- Fast searching with SQLite-based caching
+- Progressive output for immediate feedback
 - Parallel processing for improved performance
 - Output in text or JSON format
-- Detailed font information display
 
 ## Installation
 
@@ -27,90 +26,72 @@ cargo install fontgrep
 ### Basic Font Searching
 
 ```bash
-# Find variable fonts (without cache)
-fontgrep find --variable /path/to/fonts
+# Find variable fonts
+fontgrep --variable /path/to/fonts
 
-# Find fonts with specific features (without cache)
-fontgrep find -f smcp,onum /path/to/fonts
+# Find fonts with specific features
+fontgrep -f smcp,onum /path/to/fonts
 
-# Find fonts supporting specific scripts (without cache)
-fontgrep find -s latn,cyrl /path/to/fonts
+# Find fonts supporting specific scripts
+fontgrep -s latn,cyrl /path/to/fonts
 
-# Find fonts by name pattern (without cache)
-fontgrep find -n "Roboto.*Mono" /path/to/fonts
+# Find fonts by name pattern
+fontgrep -n "Roboto.*Mono" /path/to/fonts
 
-# Find fonts supporting specific Unicode ranges (without cache)
-fontgrep find -u "U+0041-U+005A,U+0061-U+007A" /path/to/fonts
+# Find fonts supporting specific Unicode ranges
+fontgrep -u "U+0041-U+005A,U+0061-U+007A" /path/to/fonts
 
-# Find fonts with specific tables (without cache)
-fontgrep find -T GPOS,GSUB /path/to/fonts
+# Find fonts with specific tables
+fontgrep -T GPOS,GSUB /path/to/fonts
+
+# Find fonts supporting specific text
+fontgrep -t "Hello World" /path/to/fonts
 ```
 
-### Fast Searching with Cache
+### Combining Search Criteria
 
 ```bash
-# Fast search for variable fonts (with cache)
-fontgrep fast --variable /path/to/fonts
+# Find variable fonts with small caps feature
+fontgrep --variable -f smcp /path/to/fonts
 
-# Fast search for fonts with specific features (with cache)
-fontgrep fast -f smcp,onum /path/to/fonts
-```
+# Find fonts supporting both Latin and Cyrillic scripts
+fontgrep -s latn,cyrl /path/to/fonts
 
-### Cache Management
-
-```bash
-# Save fonts to the cache
-fontgrep save /path/to/fonts
-
-# Force update the cache even if fonts haven't changed
-fontgrep save --force /path/to/fonts
-
-# List all saved fonts in the cache
-fontgrep saved
-
-# Remove missing fonts from the cache
-fontgrep forget
-```
-
-### Font Information
-
-```bash
-# Show information about a font
-fontgrep font /path/to/font.ttf
-
-# Show detailed information about a font
-fontgrep font -d /path/to/font.ttf
+# Find fonts with specific name pattern and features
+fontgrep -n "Roboto" -f liga,kern /path/to/fonts
 ```
 
 ### Output Formats
 
 ```bash
 # Output in JSON format
-fontgrep find -j /path/to/fonts
+fontgrep -j /path/to/fonts
 
-# Output in JSON format (alternative)
-fontgrep --json find /path/to/fonts
+# Combine JSON output with search criteria
+fontgrep -j -f smcp,onum /path/to/fonts
 ```
 
-## Configuration
+## Command-Line Options
 
-- **Cache Commands**: Use `fast` for cached searches and `find` for direct searches without cache.
-- **Cache Location**: Use `--cache-path` to specify a custom cache location (defaults to user's data directory).
-- **Parallel Jobs**: Use `-j/--jobs` to control the number of parallel jobs (defaults to CPU core count).
-- **Verbose Output**: Use `-v/--verbose` for detailed logging.
+- `-a, --axes <AXES>`: Comma-separated list of OpenType variation axes to search for (e.g., wght,wdth)
+- `-f, --features <FEATURES>`: Comma-separated list of OpenType features to search for (e.g., smcp,onum)
+- `-s, --scripts <SCRIPTS>`: Comma-separated list of OpenType script tags to search for (e.g., latn,cyrl)
+- `-T, --tables <TABLES>`: Comma-separated list of OpenType table tags to search for (e.g., GPOS,GSUB)
+- `-v, --variable`: Only show variable fonts that support OpenType Font Variations
+- `-n, --name <NAME>`: Regular expressions to match against font names
+- `-u, --codepoints <CODEPOINTS>`: Unicode codepoints or ranges to search for (e.g., U+0041-U+005A,U+0061)
+- `-t, --text <TEXT>`: Text string to check for support
+- `-J, --jobs <JOBS>`: Number of parallel jobs to use (defaults to CPU core count)
+- `--verbose`: Enable verbose output
+- `-j, --json`: Output results in JSON format
+- `-h, --help`: Print help information
+- `-V, --version`: Print version information
 
 ## Performance
 
 - Uses memory mapping for efficient font file access
-- Maintains a SQLite cache with optimized indices
 - Employs parallel processing for searching and font analysis
-- Uses WAL mode for improved database concurrency
-
-## Error Handling
-
-- Graceful error recovery with detailed error messages
-- Proper cleanup of resources
-- Comprehensive logging for debugging
+- Provides progressive output for immediate feedback
 
 ## Development
 
@@ -139,5 +120,5 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 ## Acknowledgments
 
 - Uses [skrifa](https://github.com/googlefonts/skrifa) for font parsing
-- Uses [rusqlite](https://github.com/rusqlite/rusqlite) for SQLite database access
-- Uses [clap](https://github.com/clap-rs/clap) for command-line argument parsing 
+- Uses [clap](https://github.com/clap-rs/clap) for command-line argument parsing
+- Uses [jwalk](https://github.com/jessegrosjean/jwalk) for parallel directory traversal 

--- a/TODO.md
+++ b/TODO.md
@@ -1,65 +1,10 @@
-# Fontgrep TODO
 
+# fontgrep TODO
 
-## 1. Performance Optimization
+- [ ] Add better error messages for common font parsing errors
+- [ ] Handle TTC (TrueType Collection) files properly
+- [ ] Add graceful fallbacks for fonts with minor corruption
+- [ ] Add unit tests for core functionality
+- [ ] Add integration tests for end-to-end workflows
+- [ ] Test with real font files
 
-- [ ] **Optimize charset generation**
-  - Replace the linear scan with direct charmap iteration:
-
-```rust
-pub fn create_charset(font: &FontRef) -> BTreeSet<u32> {
-    font.charmap().iter()
-        .filter(|(cp, _)| !is_invalid_unicode(*cp))
-        .map(|(cp, _)| cp)
-        .collect()
-}
-```
-
-- [ ] **Improve database operations**
-  - Use prepared statements for repetitive operations
-  - Add appropriate indexes for common query patterns
-  - Implement transaction batching for bulk operations
-
-## 2. Error Handling
-
-- [ ] **Audit and replace remaining `unwrap()`/`expect()` calls**
-  - Identify all instances in the codebase
-  - Replace with proper error propagation using `?` operator
-  - Ensure meaningful error messages
-
-- [ ] **Improve error handling for font parsing**
-  - Add better error messages for common font parsing errors
-  - Handle TTC (TrueType Collection) files properly
-  - Add graceful fallbacks for fonts with minor corruption
-
-## 3. Testing
-
-- [ ] **Add comprehensive tests**
-  - Add unit tests for core functionality
-  - Add integration tests for end-to-end workflows
-  - Test with real font files
-
-## 4. Documentation
-
-- [ ] **Improve documentation**
-  - Update README with new command names and examples
-  - Document CLI options more thoroughly
-  - Add more doc comments to public API
-
-## 5. Memory Optimization
-
-- [ ] **Reduce memory usage**
-  - Implement streaming for large result sets
-  - Consider lazy loading for large font data
-
-## 6. Implementation Priority
-
-1. ~~CLI improvements~~ (completed)
-2. Error handling improvements (highest priority)
-3. Performance optimizations for charset generation
-4. Database operation improvements
-5. Testing additions
-6. Documentation improvements
-7. Memory optimizations
-
-These focused improvements will significantly enhance the reliability, performance, and usability of fontgrep while maintaining the current functionality.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,6 @@ pub struct Cli {
 
     /// Enable verbose output
     #[arg(
-        short,
         long,
         help = "Enable verbose output",
         long_help = "Enable verbose output mode that shows additional information \
@@ -32,7 +31,7 @@ pub struct Cli {
 
     /// Output as JSON
     #[arg(
-        short,
+        short = 'j',
         long,
         help = "Output as JSON",
         long_help = "Output results in JSON format for machine processing. \
@@ -119,7 +118,7 @@ pub(crate) struct SearchArgs {
 
     /// Only show variable fonts
     #[arg(
-        short,
+        short = 'v',
         long,
         help = "Only show variable fonts",
         long_help = "Only show variable fonts that support OpenType Font Variations."
@@ -162,7 +161,7 @@ pub(crate) struct SearchArgs {
 
     /// Number of parallel jobs to use
     #[arg(
-        short,
+        short = 'J',
         long,
         default_value_t = num_cpus::get(),
         help = "Number of parallel jobs to use",
@@ -187,10 +186,13 @@ struct InfoArgs {
 /// Execute the command
 pub fn execute(cli: Cli) -> Result<()> {
     let query = FontQuery::from(&cli.search_args);
-    let results = query.execute()?;
+    let results = query.execute(cli.json)?;
 
-    // Output results
-    output_results(&results, cli.json)?;
+    // Output results only for JSON mode
+    // (normal output is already printed during execution)
+    if cli.json {
+        output_results(&results, cli.json)?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Some cleanup to README, going back to "jwalk" because this implementation allows progressive printout (the "rayon" take didn't print the matches until all files were traversed)