### PR TITLE
Update installation command for fontgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A command-line tool for searching and analyzing font files based on various crit
 ## Installation
 
 ```bash
-cargo install fontgrep
+cargo install --git https://github.com/simoncozens/fontgrep
 ```
 
 ## Usage


### PR DESCRIPTION
cargo install fontgrep

This failed for me with

error: could not find `fontgrep` in registry `crates-io` with version `*`

But this worked